### PR TITLE
Added test for ribbon-secured

### DIFF
--- a/netflix/ribbon-secure/pom.xml
+++ b/netflix/ribbon-secure/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.swarm.ts</groupId>
+        <artifactId>ts-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>ts-netflix-ribbon-secured</artifactId>
+    <packaging>war</packaging>
+
+    <name>Swarm TS: Netflix: Ribbon secured</name>
+
+    <properties>
+        <version.org.keycloak.everything>2.5.5.Final</version.org.keycloak.everything>
+    </properties>
+
+     <dependencies>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>ribbon-secured</artifactId>
+            <version>${version.org.wildfly.swarm}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>keycloak</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <scope>test</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>msc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-network</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+                <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>jboss/keycloak:${version.org.keycloak.everything}</name>
+                            <alias>ts-nextflix-ribbon-secured</alias>
+                            <run>
+                                <ports>
+                                    <port>8180:8080</port>
+                                </ports>
+                                <env>
+                                    <KEYCLOAK_USER>admin</KEYCLOAK_USER>
+                                    <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
+                                </env>
+                                <wait>
+                                    <time>600000</time>
+                                    <log>WFLYSRV0025: Keycloak</log>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/MockTopologyConnector.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/MockTopologyConnector.java
@@ -1,0 +1,45 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import org.jboss.as.network.SocketBinding;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.swarm.topology.TopologyConnector;
+import org.wildfly.swarm.topology.runtime.Registration;
+import org.wildfly.swarm.topology.runtime.TopologyManager;
+
+public class MockTopologyConnector implements TopologyConnector, Service<MockTopologyConnector> {
+    InjectedValue<TopologyManager> topology = new InjectedValue<>();
+
+    @Override
+    public void advertise(String name, SocketBinding binding, String... tags) throws Exception {
+        Registration registration = new Registration("Mock", name,
+                binding.getAddress().getHostAddress(), binding.getAbsolutePort(), tags);
+        topology.getValue().register(registration);
+    }
+
+    @Override
+    public void unadvertise(String name, SocketBinding binding) throws Exception {
+        TopologyManager topology = this.topology.getValue();
+        topology.registrationsForService(name)
+                .stream()
+                .filter(r -> r.getAddress().equals(binding.getAddress().getHostAddress())
+                        && r.getPort() == binding.getAbsolutePort())
+                .forEach(topology::unregister);
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+    }
+
+    @Override
+    public void stop(StopContext context) {
+    }
+
+    @Override
+    public MockTopologyConnector getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+}

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/MockTopologyConnectorServiceActivator.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/MockTopologyConnectorServiceActivator.java
@@ -1,0 +1,20 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceRegistryException;
+import org.jboss.msc.service.ServiceTarget;
+import org.wildfly.swarm.topology.runtime.TopologyManager;
+import org.wildfly.swarm.topology.runtime.TopologyManagerActivator;
+
+public class MockTopologyConnectorServiceActivator implements ServiceActivator {
+    @Override
+    public void activate(ServiceActivatorContext context) throws ServiceRegistryException {
+        ServiceTarget target = context.getServiceTarget();
+
+        MockTopologyConnector service = new MockTopologyConnector();
+        target.addService(TopologyManagerActivator.CONNECTOR_SERVICE_NAME, service)
+                .addDependency(TopologyManagerActivator.SERVICE_NAME, TopologyManager.class, service.topology)
+                .install();
+    }
+}

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/ProtectedAreaServlet.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/ProtectedAreaServlet.java
@@ -1,0 +1,31 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.wildfly.swarm.topology.Topology;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@WebServlet("/protected")
+public class ProtectedAreaServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String response = "";
+        try {
+            Topology topology = Topology.lookup();
+            Map<String, List<Topology.Entry>> entries = topology.asMap();
+            for (String key : entries.keySet()) {               
+                response = response + key;
+            }
+        } catch (Exception e) {
+            throw new ServletException();
+        }
+        resp.getWriter().print(response);
+    }
+}

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/keycloak.json
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/keycloak.json
@@ -1,0 +1,7 @@
+{
+  "realm": "test-realm",
+  "auth-server-url": "http://localhost:8180/auth",
+  "resource": "test-client",
+  "ssl-required" : "external",
+  "public-client": true
+}

--- a/netflix/ribbon-secure/src/test/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RibbonSecuredTopologyTest.java
+++ b/netflix/ribbon-secure/src/test/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RibbonSecuredTopologyTest.java
@@ -1,0 +1,156 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.message.BasicNameValuePair;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.wildfly.swarm.keycloak.Secured;
+import org.wildfly.swarm.netflix.ribbon.RibbonArchive;
+import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.ts.netflix.ribbon.secured.MockTopologyConnector;
+import org.wildfly.swarm.ts.netflix.ribbon.secured.MockTopologyConnectorServiceActivator;
+
+@RunWith(Arquillian.class)
+public class RibbonSecuredTopologyTest {
+    
+    private static Keycloak keycloak;
+
+    private static String userId;
+    
+    private static final Pattern LOGIN_FORM_URL_PATTERN = Pattern.compile("<form .*? action=\"(.*?)\"");
+
+    @Deployment(testable=false) 
+    public static Archive getDeployment() {
+
+        WebArchive deployment = ShrinkWrap.create(WebArchive.class);
+        deployment.addClass(ProtectedAreaServlet.class)
+            .addClass(MockTopologyConnector.class).addClass(MockTopologyConnectorServiceActivator.class)
+        .addAsServiceProvider(ServiceActivator.class, MockTopologyConnectorServiceActivator.class);
+
+        deployment.addAsWebInfResource(new File("src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/keycloak.json"), "keycloak.json");
+
+        deployment.as(JARArchive.class).addModule("org.wildfly.swarm.topology", "runtime"); // needed for mock topology connector
+        deployment.as(JARArchive.class).addModule("org.jboss.as.network");                  // needed for mock topology connector
+        deployment.as(RibbonArchive.class).advertise("ts-netflix-ribbon-secured");
+
+        deployment.as(Secured.class)
+                .protect("/protected/*")
+                .withMethod( "GET" )
+                .withRole( "*" );
+
+        return deployment;
+    }
+
+    @BeforeClass
+    public static void setupKeycloakRealm() {
+        keycloak = Keycloak.getInstance("http://localhost:8180/auth", "master", "admin", "admin", "admin-cli");
+
+        RealmRepresentation realm = new RealmRepresentation();
+        realm.setRealm("test-realm");
+        realm.setDisplayName("Testing Realm");
+        realm.setEnabled(true);
+        keycloak.realms().create(realm);
+
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId("test-client");
+        client.setProtocol("openid-connect");
+        List<String> uris = new ArrayList<String>();
+        uris.add("http://localhost:8080/protected/*");
+        client.setRedirectUris(uris);
+        client.setPublicClient(true);
+        Response response = keycloak.realms().realm("test-realm").clients().create(client);
+        response.close();
+
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("test-user");
+        user.setEnabled(true);
+        response = keycloak.realms().realm("test-realm").users().create(user);
+        userId = getIdOfCreatedUser(response);
+        response.close();
+
+        CredentialRepresentation credential = new CredentialRepresentation();
+        credential.setType(CredentialRepresentation.PASSWORD);
+        credential.setValue("test-password");
+        credential.setTemporary(false);
+        keycloak.realms().realm("test-realm").users().get(userId).resetPassword(credential);
+    }
+
+    @AfterClass
+    public static void tearDownKeycloakRealm() {
+        keycloak.realms().realm("test-realm").remove();
+        keycloak.close();
+    }
+
+    private static String getIdOfCreatedUser(Response response) {
+        if (!response.getStatusInfo().equals(Response.Status.CREATED)) {
+            Response.StatusType statusInfo = response.getStatusInfo();
+            throw new IllegalStateException("Creating user failed; expected 201 but returned " + statusInfo.getStatusCode());
+        }
+        URI location = response.getLocation();
+        if (location == null) {
+            throw new IllegalStateException("Creating user failed; expected location to be returned");
+        }
+        String path = location.getPath();
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+
+    
+   
+    @Test
+    @RunAsClient
+    public void test() throws Exception {
+
+        Executor executor = Executor.newInstance().use(new BasicCookieStore());
+
+        String response = executor.execute(Request.Get("http://localhost:8080/protected")).returnContent().asString();
+        assertThat(response).contains("Testing Realm");
+
+        List<NameValuePair> loginForm = Arrays.asList(
+                new BasicNameValuePair("username", "test-user"),
+                new BasicNameValuePair("password", "test-password")
+        );
+        Matcher matcher = LOGIN_FORM_URL_PATTERN.matcher(response);
+        boolean found = matcher.find();
+        assertThat(found).as("Expected login form").isTrue();
+        String loginPostUrl = matcher.group(1);
+        HttpResponse loginResponse = executor.execute(Request.Post(loginPostUrl).bodyForm(loginForm)).returnResponse();
+
+        assertThat(loginResponse.getStatusLine().getStatusCode()).isEqualTo(302);
+        String location = loginResponse.getFirstHeader("Location").getValue();
+        assertThat(location).as("Expected redirect after login").isNotNull();
+
+        response = executor.execute(Request.Get(location)).returnContent().asString();
+        assertThat(response).contains("ts-netflix-ribbon-secured");
+
+    }
+}


### PR DESCRIPTION
Hi Ladislav.
I am not very happy about this PR, as I initially wanted to implement a test using Ribbon secured client together with JAX-RS, but I couldn't make it work. I tested some keycloak configurations but no way.

I also couldn't make it work using two Swarm containers (1 keycloak server, 1 "normal") so I could stop the normal one and test fallback (like the already merged ribbon tests), but again faced multiple problems and found no solution.

Anyway, seems like an acceptable basic test for ribbon-secured IMHO.

IMPORTANT: can you check why docker isn't starting and stopping automatically? Right now this should be done manuall by adding docker:start etc...