### PR TITLE
Added test for ribbon-secured

### DIFF
--- a/netflix/ribbon-secure/pom.xml
+++ b/netflix/ribbon-secure/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.swarm.ts</groupId>
+        <artifactId>ts-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <artifactId>ts-netflix-ribbon-secured</artifactId>
+    <packaging>war</packaging>
+
+    <name>Swarm TS: Netflix: Ribbon secured</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>ribbon-secured</artifactId>
+            <version>${version.org.wildfly.swarm}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+        <!-- KEYCLOAK -->
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>keycloak</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson2-provider</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-authz-client</artifactId>
+            <version>${version.org.keycloak.everything}</version>
+            <scope>test</scope>
+         </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>msc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-network</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>arquillian</artifactId>
+            <scope>test</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+           <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>jboss/keycloak:${version.org.keycloak.everything}</name>
+                            <alias>ts-nextflix-ribbon-secured</alias>
+                            <run>
+                                <ports>
+                                    <port>8180:8080</port>
+                                </ports>
+
+                                <env>
+                                    <KEYCLOAK_USER>admin</KEYCLOAK_USER>
+                                    <KEYCLOAK_PASSWORD>admin</KEYCLOAK_PASSWORD>
+                                </env>
+                                <wait>
+                                    <time>600000</time>
+                                    <log>WFLYSRV0025: Keycloak</log>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-plugin</artifactId>
+                <executions>
+                        <execution>
+                            <id>start</id>
+                            <phase>none</phase>
+                        </execution>
+                        <execution>
+                            <id>stop</id>
+                            <phase>none</phase>
+                        </execution>
+                    </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/HelloResource.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/HelloResource.java
@@ -1,0 +1,30 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class HelloResource {
+
+    private static AtomicBoolean enabled = new AtomicBoolean(true);
+
+    @GET
+    @Path("protected")
+    public Response get() {
+        if (enabled.get()) {
+            return Response.ok().entity("Hello, World!").build();
+        } else {
+            return Response.serverError().build();
+        }
+    }
+
+    @POST
+    @Path("disable")
+    public void disable() {
+        enabled.set(false);
+    }
+}

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/MockTopologyConnector.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/MockTopologyConnector.java
@@ -1,0 +1,45 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import org.jboss.as.network.SocketBinding;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.swarm.topology.TopologyConnector;
+import org.wildfly.swarm.topology.runtime.Registration;
+import org.wildfly.swarm.topology.runtime.TopologyManager;
+
+public class MockTopologyConnector implements TopologyConnector, Service<MockTopologyConnector> {
+    InjectedValue<TopologyManager> topology = new InjectedValue<>();
+
+    @Override
+    public void advertise(String name, SocketBinding binding, String... tags) throws Exception {
+        Registration registration = new Registration("Mock", name,
+                binding.getAddress().getHostAddress(), binding.getAbsolutePort(), tags);
+        topology.getValue().register(registration);
+    }
+
+    @Override
+    public void unadvertise(String name, SocketBinding binding) throws Exception {
+        TopologyManager topology = this.topology.getValue();
+        topology.registrationsForService(name)
+                .stream()
+                .filter(r -> r.getAddress().equals(binding.getAddress().getHostAddress())
+                        && r.getPort() == binding.getAbsolutePort())
+                .forEach(topology::unregister);
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+    }
+
+    @Override
+    public void stop(StopContext context) {
+    }
+
+    @Override
+    public MockTopologyConnector getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+}

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/MockTopologyConnectorServiceActivator.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/MockTopologyConnectorServiceActivator.java
@@ -1,0 +1,20 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceRegistryException;
+import org.jboss.msc.service.ServiceTarget;
+import org.wildfly.swarm.topology.runtime.TopologyManager;
+import org.wildfly.swarm.topology.runtime.TopologyManagerActivator;
+
+public class MockTopologyConnectorServiceActivator implements ServiceActivator {
+    @Override
+    public void activate(ServiceActivatorContext context) throws ServiceRegistryException {
+        ServiceTarget target = context.getServiceTarget();
+
+        MockTopologyConnector service = new MockTopologyConnector();
+        target.addService(TopologyManagerActivator.CONNECTOR_SERVICE_NAME, service)
+                .addDependency(TopologyManagerActivator.SERVICE_NAME, TopologyManager.class, service.topology)
+                .install();
+    }
+}

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RestApplication.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RestApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/")
+public class RestApplication extends Application {
+}

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RibbonSecuredClientResource.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RibbonSecuredClientResource.java
@@ -1,0 +1,39 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.wildfly.swarm.netflix.ribbon.secured.client.SecuredRibbonResourceFactory;
+
+import com.netflix.ribbon.http.HttpRequestTemplate;
+import com.netflix.ribbon.http.HttpRequestTemplate.Builder;
+import com.netflix.ribbon.http.HttpResourceGroup;
+
+import io.netty.buffer.ByteBuf;
+
+@Path("/")
+public class RibbonSecuredClientResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/test")
+    public Response test(TokenDTO tokenDTO) {
+        HttpResourceGroup group = SecuredRibbonResourceFactory.INSTANCE.createHttpResourceGroup("ts-netflix-ribbon-secured");
+
+        Builder<ByteBuf> builder = group.newTemplateBuilder("template")
+                .withMethod("GET")
+                .withUriTemplate("/protected")
+                .withHeader("Authorization", "Bearer " + tokenDTO.getToken())
+                .withFallbackProvider(new RibbonTestFallbackHandler());
+
+        HttpRequestTemplate<ByteBuf> template = builder.build();
+
+        ByteBuf response = template.requestBuilder().build().execute();
+        return Response.ok().entity(response.toString(StandardCharsets.UTF_8)).build();
+    }
+}

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RibbonTestFallbackHandler.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RibbonTestFallbackHandler.java
@@ -1,0 +1,21 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import com.netflix.hystrix.HystrixInvokableInfo;
+import com.netflix.ribbon.hystrix.FallbackHandler;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import rx.Observable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class RibbonTestFallbackHandler implements FallbackHandler<ByteBuf> {
+    @Override
+    public Observable<ByteBuf> getFallback(HystrixInvokableInfo<?> hystrixInfo, Map<String, Object> requestProperties) {
+        String fallback = "Fallback string";
+        byte[] bytes = fallback.getBytes(StandardCharsets.UTF_8);
+        ByteBuf byteBuf = UnpooledByteBufAllocator.DEFAULT.buffer(bytes.length);
+        byteBuf.writeBytes(bytes);
+        return Observable.just(byteBuf);
+    }
+}

--- a/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/TokenDTO.java
+++ b/netflix/ribbon-secure/src/main/java/org/wildfly/swarm/ts/netflix/ribbon/secured/TokenDTO.java
@@ -1,0 +1,27 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class TokenDTO {
+
+    private String token;
+
+    public TokenDTO() {
+    }
+
+    public TokenDTO(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/netflix/ribbon-secure/src/test/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RibbonSecuredTopologyIT.java
+++ b/netflix/ribbon-secure/src/test/java/org/wildfly/swarm/ts/netflix/ribbon/secured/RibbonSecuredTopologyIT.java
@@ -1,0 +1,182 @@
+package org.wildfly.swarm.ts.netflix.ribbon.secured;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.BasicCookieStore;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.authorization.client.AuthzClient;
+import org.keycloak.authorization.client.Configuration;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.util.JsonSerialization;
+import org.wildfly.swarm.jaxrs.JAXRSArchive;
+import org.wildfly.swarm.keycloak.Secured;
+import org.wildfly.swarm.netflix.ribbon.RibbonArchive;
+import org.wildfly.swarm.spi.api.JARArchive;
+import org.wildfly.swarm.ts.netflix.ribbon.secured.MockTopologyConnector;
+import org.wildfly.swarm.ts.netflix.ribbon.secured.MockTopologyConnectorServiceActivator;
+
+
+@RunWith(Arquillian.class)
+public class RibbonSecuredTopologyIT {
+
+    private static final String TESTING_REALM_DISPLAY_NAME="Ribbon secured testing Realm";
+
+    private static AuthzClient authzClient;
+
+    private static Keycloak keycloak;
+
+    private static String userId;
+
+    @Deployment(testable= false)
+    public static Archive<?> getDeployment() {
+
+        JAXRSArchive deployment = ShrinkWrap.create(JAXRSArchive.class);
+
+        deployment.addClass(HelloResource.class).addClass(RestApplication.class)
+            .addClass(RibbonSecuredClientResource.class).addClass(RibbonTestFallbackHandler.class)
+            .addClass(TokenDTO.class)
+            .addClass(MockTopologyConnector.class).addClass(MockTopologyConnectorServiceActivator.class)
+            .addAsServiceProvider(ServiceActivator.class, MockTopologyConnectorServiceActivator.class);
+
+        deployment.addAsWebInfResource(new File("src/test/resources/keycloak.json"), "keycloak.json");
+
+        deployment.as(JARArchive.class).addModule("org.wildfly.swarm.topology", "runtime"); // needed for mock topology connector
+        deployment.as(JARArchive.class).addModule("org.jboss.as.network");                  // needed for mock topology connector
+        deployment.as(RibbonArchive.class).advertise("ts-netflix-ribbon-secured");
+
+        deployment.as(Secured.class)
+                .protect("/protected")
+                .withMethod("GET")
+                .withRole("*");
+
+        return deployment;
+    }
+
+    @BeforeClass
+    public static void setupKeycloakRealm() throws Exception {
+
+        keycloak = Keycloak.getInstance("http://localhost:8180/auth", "master", "admin", "admin", "admin-cli");
+
+        RealmRepresentation realm = new RealmRepresentation();
+        realm.setRealm("test-realm");
+        realm.setDisplayName(TESTING_REALM_DISPLAY_NAME);
+        realm.setEnabled(true);
+        realm.setSslRequired("external");
+        keycloak.realms().create(realm);
+
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId("test-client");
+        client.setProtocol("openid-connect");
+        List<String> uris = new ArrayList<String>();
+        uris.add("http://localhost:8080/protected/*");
+        client.setRedirectUris(uris);
+        client.setClientAuthenticatorType("client-secret");
+        client.setSecret("19666a4f-32dd-4049-b082-684c74115f28");
+        client.setEnabled(true);
+
+        Response response = keycloak.realms().realm("test-realm").clients().create(client);
+        response.close();
+
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("test-user");
+        user.setEnabled(true);
+        response = keycloak.realms().realm("test-realm").users().create(user);
+        userId = getIdOfCreatedUser(response);
+        response.close();
+
+        CredentialRepresentation credential = new CredentialRepresentation();
+        credential.setType(CredentialRepresentation.PASSWORD);
+        credential.setValue("test-password");
+        credential.setTemporary(false);
+        keycloak.realms().realm("test-realm").users().get(userId).resetPassword(credential);
+
+        authzClient = createAuthzCLient("http://localhost:8180/auth");
+    }
+
+    @AfterClass
+    public static void tearDownKeycloakRealm() {
+        keycloak.realms().realm("test-realm").remove();
+        keycloak.close();
+    }
+
+    private static String getIdOfCreatedUser(Response response) {
+        if (!response.getStatusInfo().equals(Response.Status.CREATED)) {
+            Response.StatusType statusInfo = response.getStatusInfo();
+            throw new IllegalStateException("Creating user failed; expected 201 but returned " + statusInfo.getStatusCode());
+        }
+        URI location = response.getLocation();
+        if (location == null) {
+            throw new IllegalStateException("Creating user failed; expected location to be returned");
+        }
+        String path = location.getPath();
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+
+    private static AuthzClient createAuthzCLient(String ssoAuthUrl) throws Exception {
+        InputStream configStream = RibbonSecuredTopologyIT.class.getClassLoader().getResourceAsStream("keycloak.json");
+        if (configStream == null) {
+            throw new IllegalStateException("Could not find any keycloak.json file in classpath.");
+        }
+
+        Configuration baseline = JsonSerialization.readValue(
+                configStream,
+                Configuration.class,
+                true
+        );
+
+        return AuthzClient.create(baseline);
+    }
+
+    @Test
+    public void testAccessSecuredContentNoToken() throws Exception {
+        Executor executor = Executor.newInstance().use(new BasicCookieStore());
+
+        String response = executor.execute(Request.Get("http://localhost:8080/protected")).
+                returnContent().asString();
+        assertThat(response).contains(TESTING_REALM_DISPLAY_NAME);
+    }
+
+    @Test
+    public void testAccessSecuredContentTokenWithFallback() throws Exception {
+        Executor executor = Executor.newInstance().use(new BasicCookieStore());
+
+        String token = authzClient.obtainAccessToken("test-user", "test-password").getToken();
+
+        String json = "{\"token\":\"" + token + "\"}";
+
+        String response = executor.execute(Request.Post("http://localhost:8080/test").
+                bodyString(json, ContentType.APPLICATION_JSON)).returnContent().asString();
+        assertThat(response).contains("Hello, World!");
+
+        Request.Post("http://localhost:8080/disable").execute().discardContent();
+
+        response = Request.Post("http://localhost:8080/test").
+                bodyString(json, ContentType.APPLICATION_JSON).execute().returnContent().asString();
+        assertThat(response).contains("Fallback string");
+    }
+}

--- a/netflix/ribbon-secure/src/test/resources/keycloak.json
+++ b/netflix/ribbon-secure/src/test/resources/keycloak.json
@@ -1,0 +1,8 @@
+{
+  "realm": "test-realm",
+  "auth-server-url": "http://localhost:8180/auth",
+  "resource": "test-client",
+  "credentials": {
+    "secret": "19666a4f-32dd-4049-b082-684c74115f28"
+   }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>microprofile</module>
 
         <module>netflix/ribbon</module>
+        <module>netflix/ribbon-secure</module>
 
         <module>protocols/ajp</module>
         <module>protocols/https</module>


### PR DESCRIPTION
At last @Ladicek !! About the pull, take into account I couldn't use same interface for creating a Ribbon client (using annotations), as we had to add a dynamic value for Authorization HTTP header.
